### PR TITLE
refactor: Check latest before storing latest papers

### DIFF
--- a/src/pwcode/utils/WebReader.py
+++ b/src/pwcode/utils/WebReader.py
@@ -54,7 +54,8 @@ class WebReader:
                 latest.append(paper_id)
 
         logger.info("Number of latest papers: %s", len(latest))
-        self.__store_latest(latest, cache)
+        if len(latest) != 0:
+            self.__store_latest(latest, cache)
 
         return latest
 


### PR DESCRIPTION
If server API is updated with new papers but website is not updated, then there might be API calls which are redundant. By checking latest array, duplicate calls can be prevented.